### PR TITLE
Make pathRegExp overridable

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -5,10 +5,9 @@ import { Meteor }   from 'meteor/meteor';
 import { Tracker }  from 'meteor/tracker';
 import { page, qs } from './modules.js';
 
-const pathRegExp = /(:[\w\(\)\\\+\*\.\?\[\]\-]+)+/g;
-
 class Router {
   constructor() {
+    this.pathRegExp = /(:[\w\(\)\\\+\*\.\?\[\]\-]+)+/g;
     this.globals = [];
     this.subscriptions = Function.prototype;
     this.Renderer = new BlazeRenderer();
@@ -211,7 +210,7 @@ class Router {
       path += '/' + this._basePath + '/';
     }
 
-    path += pathDef.replace(pathRegExp, (key) => {
+    path += pathDef.replace(this.pathRegExp, (key) => {
       const firstRegexpChar = key.indexOf('(');
       // get the content behind : and (\\d+/)
       key = key.substring(1, (firstRegexpChar > 0) ? firstRegexpChar : undefined);


### PR DESCRIPTION
Resolves https://github.com/VeliovGroup/flow-router/issues/25

```js
import { FlowRouter } from 'meteor/ostrio:flow-router-extra'

FlowRouter.pathRegExp = /(:[\w\(\)\\\+\*\.\?\[\]]+)+/g // Dashes `-` are also path separators

FlowRouter.group({
  ...
})
```