### PR TITLE
Eliminate duplicate template name

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -59,7 +59,7 @@ Template.index.events({ /* ... */ });
 #### Create loading template
 ```handlebars
 <!-- /imports/client/loading/loading.html -->
-<template name="index">
+<template name="loading">
   Loading...
 </template>
 ```


### PR DESCRIPTION
Loading template name was "index". If the code blocks on this page are brought into a project verbatim, Meteor will complain about a duplicate template name (and the `whiltewaiting()` portion of the route wouldn't work), since the index template's name is also "index".

Fixes #38 