### PR TITLE
Fix #43 by including weak dependencies and avoiding require

### DIFF
--- a/client/active.route.js
+++ b/client/active.route.js
@@ -4,10 +4,8 @@ import { check, Match } from 'meteor/check';
 import { ReactiveDict } from 'meteor/reactive-dict';
 
 let Template;
-try {
-  Template = require('meteor/templating').Template;
-} catch (e) {
-  // we're good
+if (Package['templating']) {
+  Template = Package['templating'].Template;
 }
 
 const init = (FlowRouter) => {

--- a/client/renderer.js
+++ b/client/renderer.js
@@ -5,11 +5,9 @@ import { requestAnimFrame } from './modules.js';
 let Blaze;
 let Template;
 
-try {
-  Blaze    = require('meteor/blaze').Blaze;
-  Template = require('meteor/templating').Template;
-} catch (e) {
-  // we're good
+if (Package['templating'] && Package['blaze']) {
+  Blaze    = Package['blaze'].Blaze;
+  Template = Package['templating'].Template;
 }
 
 class BlazeRenderer {

--- a/package.js
+++ b/package.js
@@ -18,7 +18,9 @@ Package.onUse(function (api) {
     'reactive-var',
     'ejson'
   ], ['client', 'server']);
-
+  
+  api.use(['templating', 'blaze'], 'client', { weak: true });
+  
   api.mainModule('client/_init.js', 'client');
   api.mainModule('server/_init.js', 'server');
 });


### PR DESCRIPTION
Not sure if this was causing the 'Template is undefined' error, but we should explicitly declare a weak dependency anyway. 

I've noticed Meteor's bundling system sometimes bugs out when you use a dependency that was not declared.