### PR TITLE
SSR basic api

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -4,7 +4,6 @@ import Route from './route.js';
 import Group from './group.js';
 import { _helpers } from '../lib/_helpers.js';
 
-
 const qs = require('qs');
 
 class Router {
@@ -14,7 +13,7 @@ class Router {
     this._routesMap = {};
     this._current = {};
     this._specialChars = ['/', '%', '+'];
-    this._encodeParam = (param) => {
+    this._encodeParam = param => {
       const paramArr = param.split('');
       let _param = '';
       for (let i = 0; i < paramArr.length; i++) {
@@ -62,7 +61,10 @@ class Router {
       queryParams,
     };
 
-    return { params, route };
+    return {
+      params: _helpers.clone(params),
+      route: _helpers.clone(route),
+    };
   }
 
   route(pathDef, options = {}) {

--- a/server/router.js
+++ b/server/router.js
@@ -182,6 +182,8 @@ class Router {
     // client only
   }
 
+  setParams(newParams) {}
+
   removeState() {
     // client only
   }

--- a/server/router.js
+++ b/server/router.js
@@ -44,7 +44,7 @@ class Router {
     };
   }
 
-  matchPath(path, queryParams) {
+  matchPath(path) {
     const params = {};
     const route = this._routes.find(r => {
       const pageRoute = new page.Route(r.pathDef);
@@ -54,17 +54,15 @@ class Router {
     if (!route) {
       return null;
     }
-    this._current = {
-      path,
-      params,
-      route,
-      queryParams,
-    };
 
     return {
       params: _helpers.clone(params),
       route: _helpers.clone(route),
     };
+  }
+
+  setCurrent(current) {
+    this._current = current;
   }
 
   route(pathDef, options = {}) {

--- a/server/router.js
+++ b/server/router.js
@@ -1,7 +1,9 @@
-import Route        from './route.js';
-import Group        from './group.js';
-import { Meteor }   from 'meteor/meteor';
-import { _helpers } from './../lib/_helpers.js';
+import { Meteor } from 'meteor/meteor';
+import page from 'page';
+import Route from './route.js';
+import Group from './group.js';
+import { _helpers } from '../lib/_helpers.js';
+
 
 const qs = require('qs');
 
@@ -10,6 +12,7 @@ class Router {
     this.pathRegExp = /(:[\w\(\)\\\+\*\.\?\[\]\-]+)+/g;
     this._routes = [];
     this._routesMap = {};
+    this._current = {};
     this.subscriptions = Function.prototype;
 
     // holds onRoute callbacks
@@ -21,8 +24,28 @@ class Router {
       },
       exit() {
         // client only
-      }
+      },
     };
+  }
+
+  matchPath(path, queryParams) {
+    const params = {};
+    const route = this._routes.find(r => {
+      const pageRoute = new page.Route(r.pathDef);
+
+      return pageRoute.match(path, params);
+    });
+    if (!route) {
+      return null;
+    }
+    this._current = {
+      path,
+      params,
+      route,
+      queryParams,
+    };
+
+    return { params, route };
   }
 
   route(pathDef, options = {}) {
@@ -51,10 +74,13 @@ class Router {
       pathDef = this._routesMap[pathDef].path;
     }
 
-    let path = pathDef.replace(this.pathRegExp, (_key) => {
+    let path = pathDef.replace(this.pathRegExp, _key => {
       const firstRegexpChar = _key.indexOf('(');
       // get the content behind : and (\\d+/)
-      let key = _key.substring(1, (firstRegexpChar > 0) ? firstRegexpChar : undefined);
+      let key = _key.substring(
+        1,
+        firstRegexpChar > 0 ? firstRegexpChar : undefined
+      );
       // remove +?*
       key = key.replace(/[\+\*\?]+/g, '');
 
@@ -68,8 +94,8 @@ class Router {
     path = path.match(/^\/{1}$/) ? path : path.replace(/\/$/, '');
 
     const strQueryParams = qs.stringify(queryParams || {});
-    if(strQueryParams) {
-      path += '?' + strQueryParams;
+    if (strQueryParams) {
+      path += `?${strQueryParams}`;
     }
 
     return path;
@@ -84,58 +110,68 @@ class Router {
     // object.
     // This is not to hide what's inside the route object, but to show
     // these are the public APIs
-    const routePublicApi = _helpers.pick(currentRoute, ['name', 'pathDef', 'path']);
-    routePublicApi.options = _helpers.omit(currentRoute.options, ['triggersEnter', 'triggersExit', 'action', 'subscriptions', 'name']);
+    const routePublicApi = _helpers.pick(currentRoute, [
+      'name',
+      'pathDef',
+      'path',
+    ]);
+    routePublicApi.options = _helpers.omit(currentRoute.options, [
+      'triggersEnter',
+      'triggersExit',
+      'action',
+      'subscriptions',
+      'name',
+    ]);
 
-    this._onRouteCallbacks.forEach((cb) => {
+    this._onRouteCallbacks.forEach(cb => {
       cb(routePublicApi);
     });
   }
-
 
   go() {
     // client only
   }
 
-
   current() {
     // client only
+    return this._current;
   }
 
   middleware() {
     // client only
   }
 
-
   getState() {
     // client only
   }
-
 
   getAllStates() {
     // client only
   }
 
+  getRouteName() {
+    return this._current.route ? this._current.route.name : undefined;
+  }
+
+  getQueryParam(key) {
+    return this._current.query ? this._current.queryParams[key] : undefined;
+  }
 
   setState() {
     // client only
   }
 
-
   removeState() {
     // client only
   }
-
 
   clearStates() {
     // client only
   }
 
-
   ready() {
     // client only
   }
-
 
   initialize() {
     // client only
@@ -149,7 +185,14 @@ class Router {
     // We need to remove the leading base path, or "/", as it will be inserted
     // automatically by `Meteor.absoluteUrl` as documented in:
     // http://docs.meteor.com/#/full/meteor_absoluteurl
-    return Meteor.absoluteUrl(this.path.apply(this, arguments).replace(new RegExp('^' + ('/' + (this._basePath || '') + '/').replace(/\/\/+/g, '/')), ''));
+    return Meteor.absoluteUrl(
+      this.path
+        .apply(this, arguments)
+        .replace(
+          new RegExp(`^${`/${this._basePath || ''}/`.replace(/\/\/+/g, '/')}`),
+          ''
+        )
+    );
   }
 }
 

--- a/server/router.js
+++ b/server/router.js
@@ -13,6 +13,23 @@ class Router {
     this._routes = [];
     this._routesMap = {};
     this._current = {};
+    this._specialChars = ['/', '%', '+'];
+    this._encodeParam = (param) => {
+      const paramArr = param.split('');
+      let _param = '';
+      for (let i = 0; i < paramArr.length; i++) {
+        if (this._specialChars.includes(paramArr[i])) {
+          _param += encodeURIComponent(encodeURIComponent(paramArr[i]));
+        } else {
+          try {
+            _param += encodeURIComponent(paramArr[i]);
+          } catch (e) {
+            _param += paramArr[i];
+          }
+        }
+      }
+      return _param;
+    };
     this.subscriptions = Function.prototype;
 
     // holds onRoute callbacks
@@ -84,7 +101,11 @@ class Router {
       // remove +?*
       key = key.replace(/[\+\*\?]+/g, '');
 
-      return fields[key] || '';
+      if (fields[key]) {
+        return this._encodeParam(`${fields[key]}`);
+      }
+
+      return '';
     });
 
     path = path.replace(/\/\/+/g, '/'); // Replace multiple slashes with single slash


### PR DESCRIPTION
(see https://github.com/VeliovGroup/flow-router/issues/10#issuecomment-429559609) 

To do SSR with FlowRouter, only a few pieces are missing and I try to add them here.

Basically with meteor, SSR works like this (react example)


```
import React from "react";
import { renderToString } from "react-dom/server";
import { onPageLoad } from "meteor/server-render";

import App from "/imports/Server.js";

onPageLoad(sink => {
  sink.renderIntoElementById("app", renderToString(
    <App location={sink.request.url} />
  ));
});
```

The `sink` parameter will contain all request params (path, queryParams, etc.). With `react-router` you usually control the rendered component inside of `<App />` depending on the location passed.

However with `FlowRouter` our routes usually look like this:

```
FlowRouter.route('/users/:userId', {
    name: 'about',
    action({userId}) {
      // using react-mounter 
      mount(MainLayout, {
        content: () => <UserPage userId={userId} />,
      });
    },
  });
```

*Notice*: `mount(Component, props)` from above basically does: `<Component {...props} />` and injects that on the body  on the client.

Ok, so if we could somehow call the right action definition inside of a `onPageLoad(sink => { ..})` callback and just call `renderToString` from the action, we were done!

So the idea would be:

```
onPageLoad(sink => {
    // 1. find the right route from FlowRouter._routes that matches the requested path (sink.request.url.path)
   // const route = FlowRouter._routes.find( ....)
   // 2. call its action (ignore the params and queryParams for the moment)
   route.action(params, queryParams)
   // somehow make route.action call sink.renderIntoElementById
  
}
```

I implemented Piece 1 in this PR:

```

  const result = FlowRouter.matchPath(
    sink.request.url.path,
    sink.request.query
  );
  if (result) {
    const { route, params } = result;
  }
    
   
```

`matchPath` will look through all routes defined and return  `{route, params} ` if found, or null otherwise. `route` is the flow router route definition and params are the path params. E.g. in our example above: if the route has this definition `/users/:userId'`  and `/users/1234` is requested, params will be `{userId: "1234"}`

with this we can call our action:

```
   // ... 
    const { query } = sink.request;
    const data = route.data ? route.data(params, query) : null;
    route.action(params, query, data);
```

*Notice*: data is an optional feature from flow-router, and can be ignored in this example.

ok, now how to get action to call `sink.renderIntoElementById` on the server?

One idea would be to pass sink to the action in a 4th argument:

` route.action(params, query, data, { sink });`

but then you need to adjust all your actions, which is not really elegant.... :-/

Ok what other api would be possible? Let's have a look how you usually render content with blaze:

```
// blaze example
FlowRouter.route("/", {
  name: "home",
  action() {  
     this.render("home")
  }
}
```

Attaching the render function to `this` is a good idea. Let's use such an api. Luckily, we can easily replace the render function with our own: 


```
// client/main.js
import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
import { mount } from 'react-mounter';

FlowRouter.Renderer = {
    render: mount
}

```

this makes the router work on the client again using react-mounter. In our routes definition we can use this api like this:

```

FlowRouter.route('/users/:userId', {
    name: 'about',
    action({userId}) {
      // replacing mount from react-mounter with this.render
      this.render(MainLayout, { 
        content: () => <UserPage userId={userId} />,
      });
    },
  });

```

Now on the server, we need to directly replace `.render` on a route using `sink` like this:

```
onPageLoad(sink => {
  const result = FlowRouter.matchPath(
    sink.request.url.path,
    sink.request.query
  );
  if (result) {
    const { route, params } = result;
    // NEW: 
    route.render = (Component, props) => {
      sink.renderIntoElementById('react-root', renderToString(<Component {...props} />);
    };
    const { query } = sink.request;
    const data = route.data ? route.data(params, query) : null;
    route.action(params, query, data, { sink });
})
```

Voilà.

*Some notes*:

- i added some additional apis on the server version of flowrouter, because i used that in my react-component
- react-mounter itself could do server side mounting, but it is restriced to `kadira:flow-router-ssr` and as both projects are abandoned, its probably better to fully replace react-mounter (even on the client)
- above code with the `sink` could also be included in FlowRouter, but i maybe do that in another PR 
- rendering on the server has pitfalls, carefully test your app through



