### PR TITLE
Add missing or pipe | operator to pathRegExp

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -7,7 +7,7 @@ import { page, qs } from './modules.js';
 
 class Router {
   constructor() {
-    this.pathRegExp = /(:[\w\(\)\\\+\*\.\?\[\]\-]+)+/g;
+    this.pathRegExp = /(:[\w\(\)\\\+\*\.\?\[\]\|\-]+)+/g;
     this.globals = [];
     this.subscriptions = Function.prototype;
     this.Renderer = new BlazeRenderer();


### PR DESCRIPTION
I want to use optional pre defined prefixes like these:

```
var group = FlowRouter.group({
  prefix: "/:partner(one|two|three)?"
})
group.route("/", {name: "base", ...)
group.route("/create", {name: "create", ...)

```

For this the pipe `|` is missing in the `Router.pathRegExp`.