### PR TITLE
Update page to 1.11.5

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -7,9 +7,9 @@
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "page": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/page/-/page-1.9.0.tgz",
-      "integrity": "sha512-vdvkkw+ow7vg/XM54hHw+r0BT9UXeGzeGupG1ICdIn7GTWe8wrr2xmo7ErlUImw22datzgUEbbqwAME18FJnJw=="
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/page/-/page-1.11.5.tgz",
+      "integrity": "sha512-0JXUHc7Y8p1cPJQbhZSwaKO3p+bU3Rgny+OM5gJMKHWHvJKan/fsE5RUzEjRQolv9DzPOSVWfSOHz0lLxK19eA=="
     },
     "path-to-regexp": {
       "version": "1.2.1",

--- a/client/router.js
+++ b/client/router.js
@@ -205,6 +205,26 @@ class Router {
     return new Group(this, options);
   }
 
+  basePath (pathStr) {
+    if (typeof pathStr === 'undefined') {
+      return this._basePath
+    }
+
+    let _basePath = pathStr || '' // in case null is passed
+
+    if (!_basePath.startsWith('/')) {
+      _basePath = `/${_basePath}`;
+    }
+
+    if (_basePath.endsWith('/')) {
+      const end = _basePath.length - 1
+      _basePath = _basePath.substring(0, end)
+    }
+
+    this._basePath = _basePath
+    return this._basePath
+  }
+
   path(_pathDef, fields = {}, queryParams) {
     let pathDef = _pathDef;
     if (this._routesMap[pathDef]) {
@@ -454,7 +474,7 @@ class Router {
         if (!path || (!self.env.reload.get() && self._current.path === path)) {
           return;
         }
-        original.call(this, path.replace(/\/\/+/g, '/'), state, dispatch, push);
+        original.call(self, path.replace(/\/\/+/g, '/'), state, dispatch, push);
       };
     });
 
@@ -464,11 +484,18 @@ class Router {
     // we are doing a hack. see .path()
     this._page.base(this._basePath);
 
-    this._page(Object.assign({
-      hashbang: !!options.hashbang,
-      decodeURLComponents: true
-    }, options.page || {}));
 
+    const pageOptions = Object.assign({
+      click: true,
+      popstate: true,
+      dispatch: false,
+      hashbang: !!options.hashbang,
+      decodeURLComponents: true,
+      window: window
+    }, options.page || {});
+
+
+    this._page.call(null, pageOptions);
     this._initialized = true;
   }
 

--- a/package.js
+++ b/package.js
@@ -42,6 +42,6 @@ Package.onTest((api) => {
 });
 
 Npm.depends({
-  page: '1.9.0',
+  page: '1.11.5',
   qs: '6.5.2'
 });

--- a/test/client/router.core.spec.js
+++ b/test/client/router.core.spec.js
@@ -614,7 +614,11 @@ Tinytest.add('Client - Router - base path - path generation', (test) => {
   _.each(['/flow', '/flow/', 'flow/', 'flow'], function(simulatedBasePath) {
     const rand = Random.id();
     setBasePath(simulatedBasePath);
-    test.equal(FlowRouter.path('/' + rand), '/flow/' + rand);
+    test.equal(FlowRouter._basePath, '/flow')
+
+    const expected = '/flow/' + rand
+    const actual = FlowRouter.path('/' + rand)
+    test.equal(actual, expected);
   });
   resetBasePath();
 });
@@ -633,7 +637,7 @@ Tinytest.add('Client - Router - base path - url generation', (test) => {
 
 function setBasePath(path) {
   FlowRouter._initialized = false;
-  FlowRouter._basePath = path;
+  FlowRouter.basePath(path);
   FlowRouter.initialize();
 }
 


### PR DESCRIPTION
NOTE: this is a work in progress PR attempting to fix #74 , since there are multiple issues to address. Not all issues may have been detected yet and regression needs to be tested as well.

Currently detected issues:

- [x] `_basePath` is chained infinitely

This isse is fixed by always transforming the path to a `/name` pattern. I am not 100% if the `page` package now won't accept other path variations as base anymore or has a bug or something.

- [x] `_basePath` is stripped. after `initialize` is called

This is fixed by setting the `dispatch` option in the `page(options)` call to `false`. This fixes the `Client - Router - base path` tests. However, there is no regression-test added yet.

- [ ] exit triggers are fired twice

We first need to find out, why the exit trigger is fired twice now, while before once