### PR TITLE
Opt-in fix for double decoded query params using FlowRouter.decodeQueryParamsOnce = true flag

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -151,7 +151,17 @@ class Router {
       // Meteor's check doesn't play nice with it.
       // So, we need to fix it by cloning it.
       // see more: https://github.com/meteorhacks/flow-router/issues/164
-      const queryParams = this._qs.parse(context.querystring);
+      
+      // In addition to the above, query params also inappropriately
+      // get decoded twice. The ternary below fixes this bug if the
+      // "decodeQueryParamsOnce" option is set to true, so that we
+      // don't break legacy applications. The "example.com" domain
+      // below is insignificant but only used to create a URL object
+      // from which we can parse out query params reliably from the
+      // still-encoded path instead of the prematurely decoded
+      // querystring.
+      // See: https://github.com/veliovgroup/flow-router/issues/78
+      const queryParams = this._qs.parse((this.decodeQueryParamsOnce) ? (new URL(context.path, "http://example.com")).searchParams.toString() : context.querystring);
       this._current = {
         path: context.path,
         params: context.params,

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@
   - [`.refresh()` method](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/refresh.md)
   - [`.reload()` method](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/reload.md)
   - [`.pathRegExp` option](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/pathRegExp.md)
+  - [`.decodeQueryParamsOnce` option](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/decodeQueryParamsOnce.md)
 - __Manipulation:__
   - [`.getParam()` method](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/getParam.md)
   - [`.getQueryParam()` method](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/getQueryParam.md)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -10,6 +10,7 @@
   - [`.refresh()` method](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/refresh.md)
   - [`.reload()` method](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/reload.md)
   - [`.pathRegExp` option](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/pathRegExp.md)
+  - [`.decodeQueryParamsOnce` option](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/decodeQueryParamsOnce.md)
 - __Manipulation:__
   - [`.getParam()` method](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/getParam.md)
   - [`.getQueryParam()` method](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/getQueryParam.md)

--- a/docs/api/decodeQueryParamsOnce.md
+++ b/docs/api/decodeQueryParamsOnce.md
@@ -1,0 +1,41 @@
+### decodeQueryParamsOnce option
+
+The current behavior of `FlowRouter.getQueryParam("...")` and `FlowRouter.current().queryParams` is to double-decode query params, but this can cause issues when, for example, you want to pass a URL with its own query parameters as a URI component, such as in an OAuth flow or a redirect after login.
+
+To solve this, you can set this option to `true` to tell FlowRouter to only decode query params once.
+
+```js
+// Allows us to pass things like encoded URLs as query params (default = false)
+FlowRouter.decodeQueryParamsOnce = true;
+```
+
+#### Example
+
+Given the URL in the address bar:
+```
+http://localhost:3000/signin?after=%2Foauth%2Fauthorize%3Fclient_id%3D123%26redirect_uri%3Dhttps%253A%252F%252Fothersite.com%252F
+```
+
+If `decodeQueryParamsOnce` is not set or set to `false` ❌ ...
+```js
+FlowRouter.getQueryParam("after");
+// returns: "/oauth/authorize?client_id=123"
+
+FlowRouter.current().queryParams;
+// returns: { after: "/oauth/authorize?client_id=123", redirect_uri: "https://othersite.com/" }
+```
+
+If `decodeQueryParamsOnce` is set to `true` ✔️ ...
+```js
+FlowRouter.getQueryParam("after");
+// returns: "/oauth/authorize?client_id=123&redirect_uri=https%3A%2F%2Fothersite.com%2F"
+
+FlowRouter.current().queryParams;
+// returns: { after: "/oauth/authorize?client_id=123&redirect_uri=https%3A%2F%2Fothersite.com%2F" }
+```
+
+The former is no longer recommended, but to maintain compatibility with legacy apps, `false` is the default value for this flag. Enabling this flag manually with `true` is recommended for all new apps. For more info, see [#78](https://github.com/veliovgroup/flow-router/issues/78).
+
+#### Further reading
+ - [`.getQueryParam()` method](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/getQueryParam.md)
+ - [`.current()` method](https://github.com/VeliovGroup/flow-router/blob/master/docs/api/current.md)

--- a/docs/full.md
+++ b/docs/full.md
@@ -375,6 +375,46 @@ Use to change the URI RegEx parser used for `params`, for more info see [#25](ht
 
 -------
 
+### decodeQueryParamsOnce option
+
+The current behavior of `FlowRouter.getQueryParam("...")` and `FlowRouter.current().queryParams` is to double-decode query params, but this can cause issues when, for example, you want to pass a URL with its own query parameters as a URI component, such as in an OAuth flow or a redirect after login.
+
+To solve this, you can set this option to `true` to tell FlowRouter to only decode query params once.
+
+```js
+// Allows us to pass things like encoded URLs as query params (default = false)
+FlowRouter.decodeQueryParamsOnce = true;
+```
+
+#### Example
+
+Given the URL in the address bar:
+```
+http://localhost:3000/signin?after=%2Foauth%2Fauthorize%3Fclient_id%3D123%26redirect_uri%3Dhttps%253A%252F%252Fothersite.com%252F
+```
+
+If `decodeQueryParamsOnce` is not set or set to `false` ❌ ...
+```js
+FlowRouter.getQueryParam("after");
+// returns: "/oauth/authorize?client_id=123"
+
+FlowRouter.current().queryParams;
+// returns: { after: "/oauth/authorize?client_id=123", redirect_uri: "https://othersite.com/" }
+```
+
+If `decodeQueryParamsOnce` is set to `true` ✔️ ...
+```js
+FlowRouter.getQueryParam("after");
+// returns: "/oauth/authorize?client_id=123&redirect_uri=https%3A%2F%2Fothersite.com%2F"
+
+FlowRouter.current().queryParams;
+// returns: { after: "/oauth/authorize?client_id=123&redirect_uri=https%3A%2F%2Fothersite.com%2F" }
+```
+
+The former is no longer recommended, but to maintain compatibility with legacy apps, `false` is the default value for this flag. Enabling this flag manually with `true` is recommended for all new apps. For more info, see [#78](https://github.com/veliovgroup/flow-router/issues/78).
+
+-------
+
 ### refresh method
 
 ```js


### PR DESCRIPTION
Hey there,

I've created this lightweight PR to fix a long-standing bug that has existed for a while that causes query params to get decoded twice, despite using `encodeURIComponent` on the query param values first. This issue has been [discussed at length here](https://github.com/veliovgroup/flow-router/issues/78#issuecomment-623519293) but never fixed (the suggested code change in the conversation didn't fix it either). The proposal that was discussed was to introduce a flag that could be turned on to opt-in to this bug fix because there was concern that fixing this bug could break existing legacy applications. So that's what I did.

To apply this fix to FlowRouter, you would just use this flag:

```js
FlowRouter.decodeQueryParamsOnce = true;
```

The change takes place only on a single line.

```js
// OLD:
const queryParams = this._qs.parse(context.querystring);

// NEW:
const queryParams = this._qs.parse((this.decodeQueryParamsOnce) ? (new URL(context.path, "http://example.com")).searchParams.toString() : context.querystring);
```

Basically, the justification here is that `context.querystring` is inappropriately decoded one additional time by the `page` library, whereas `context.path` is not, and it still contains the query string, which I was able to parse out using the `URL` class. I could have parsed it out manually, but since we don't know if there's a hash in the URL or other calamities that could occur in a URL, I just used the `URL` class to parse out the query string predictably and reliably. Since it requires a base, I give it "example.com", but this part is completely ignored and unused so therefore it's irrelevant to the output.

If this flag is not enabled, there is no change to the code as it ran before, so this will not break any existing or legacy apps.

I ran all the tests with the flag on and off, and all tests passed.

The new flag has been fully documented in all the appropriate docs and READMEs as well. The docs also offer some examples of what the results look like with this flag turned off and on.

Links to discussions about this bug (even way back to kadira):

https://github.com/veliovgroup/flow-router/issues/78
https://github.com/kadirahq/flow-router/issues/465

**Side note:**

This doesn't appear to be the only place this bug occurs. I discovered that path params share this bug as well and get prematurely decoded even prior to regex matching, but I wasn't able to come up with a fix for that one. That appears to be a whole different beast. And I can't confirm whether or not this bug exists in hashbangs. I did not check that myself. But this fixes at least query params, which are the most critical in my mind and are what we've struggled with the most.

These problems seem to stem largely from the [page](https://github.com/visionmedia/page.js) package. I found these similar issues as well:

https://github.com/visionmedia/page.js/issues/216
https://github.com/visionmedia/page.js/issues/187
https://github.com/visionmedia/page.js/issues/306

Thank you for maintaining such an important package! I know it's not easy, but your efforts are appreciated, and I hope I've helped make this PR as plug-and-play as possible. Thank you!