### PR TITLE
Flow-Router Extra Typescript types

### DIFF
--- a/package-types.json
+++ b/package-types.json
@@ -1,3 +1,3 @@
 {
     "typesEntry": "types.d.ts"
-  }
+}

--- a/package-types.json
+++ b/package-types.json
@@ -1,0 +1,3 @@
+{
+    "typesEntry": "types.d.ts"
+  }

--- a/package.js
+++ b/package.js
@@ -1,76 +1,48 @@
 Package.describe({
-    name: "ostrio:flow-router-extra",
-    summary: "Carefully extended flow-router with waitOn and template context",
-    version: "3.8.1",
-    git: "https://github.com/veliovgroup/flow-router",
-});
-
-Package.onUse((api) => {
-    api.versionsFrom("1.4");
-    api.use(
-        [
-            "modules",
-            "ecmascript",
-            "promise",
-            "tracker",
-            "reactive-dict",
-            "reactive-var",
-            "ejson",
-            "check",
-            "zodern:types",
-        ],
-        ["client", "server"]
-    );
-
-    api.use(["templating", "blaze"], "client", { weak: true });
-    api.mainModule("client/_init.js", "client");
-    api.mainModule("server/_init.js", "server");
-});
-
-Package.onTest((api) => {
-    api.use(
-        [
-            "ecmascript",
-            "tinytest",
-            "underscore",
-            "check",
-            "mongo",
-            "http",
-            "random",
-            "communitypackages:fast-render@4.0.6",
-            "communitypackages:inject-data@2.3.1",
-            "montiapm:meteorx@2.2.0",
-            "ostrio:flow-router-extra",
-            "zodern:types",
-        ],
-        ["client", "server"]
-    );
-    api.use(["reactive-var", "tracker"], "client");
-
-    api.addFiles("test/common/fast_render_route.js", ["client", "server"]);
-
-    api.addFiles("test/client/_helpers.js", "client");
-    api.addFiles("test/server/_helpers.js", "server");
-
-    api.addFiles("test/client/loader.spec.js", "client");
-    api.addFiles("test/client/route.reactivity.spec.js", "client");
-    api.addFiles("test/client/router.core.spec.js", "client");
-    api.addFiles("test/client/router.subs_ready.spec.js", "client");
-    api.addFiles("test/client/router.reactivity.spec.js", "client");
-    api.addFiles("test/client/group.spec.js", "client");
-    api.addFiles("test/client/trigger.spec.js", "client");
-    api.addFiles("test/client/triggers.js", "client");
-
-    api.addFiles("test/server/plugins/fast_render.js", "server");
-
-    api.addFiles("test/common/router.path.spec.js", ["client", "server"]);
-    api.addFiles("test/common/router.url.spec.js", ["client", "server"]);
-    api.addFiles("test/common/router.addons.spec.js", ["client", "server"]);
-    api.addFiles("test/common/route.spec.js", ["client", "server"]);
-    api.addFiles("test/common/group.spec.js", ["client", "server"]);
-});
-
-Npm.depends({
-    page: "1.9.0",
-    qs: "6.10.5",
-});
+    name: 'ostrio:flow-router-extra',
+    summary: 'Carefully extended flow-router with waitOn and template context',
+    version: '3.8.1',
+    git: 'https://github.com/veliovgroup/flow-router'
+  });
+  
+  Package.onUse((api) => {
+    api.versionsFrom('1.4');
+    api.use(['modules', 'ecmascript', 'promise', 'tracker', 'reactive-dict', 'reactive-var', 'ejson', 'check', 'zodern:types'], ['client', 'server']);
+  
+    api.use(['templating', 'blaze'], 'client', { weak: true });
+    api.mainModule('client/_init.js', 'client');
+    api.mainModule('server/_init.js', 'server');
+  });
+  
+  Package.onTest((api) => {
+    api.use(['ecmascript', 'tinytest', 'underscore', 'check', 'mongo', 'http', 'random', 'communitypackages:fast-render@4.0.6', 'communitypackages:inject-data@2.3.1', 'montiapm:meteorx@2.2.0', 'ostrio:flow-router-extra', 'zodern:types'], ['client', 'server']);
+    api.use(['reactive-var', 'tracker'], 'client');
+  
+    api.addFiles('test/common/fast_render_route.js', ['client', 'server']);
+  
+    api.addFiles('test/client/_helpers.js', 'client');
+    api.addFiles('test/server/_helpers.js', 'server');
+  
+    api.addFiles('test/client/loader.spec.js', 'client');
+    api.addFiles('test/client/route.reactivity.spec.js', 'client');
+    api.addFiles('test/client/router.core.spec.js', 'client');
+    api.addFiles('test/client/router.subs_ready.spec.js', 'client');
+    api.addFiles('test/client/router.reactivity.spec.js', 'client');
+    api.addFiles('test/client/group.spec.js', 'client');
+    api.addFiles('test/client/trigger.spec.js', 'client');
+    api.addFiles('test/client/triggers.js', 'client');
+  
+    api.addFiles('test/server/plugins/fast_render.js', 'server');
+  
+    api.addFiles('test/common/router.path.spec.js', ['client', 'server']);
+    api.addFiles('test/common/router.url.spec.js', ['client', 'server']);
+    api.addFiles('test/common/router.addons.spec.js', ['client', 'server']);
+    api.addFiles('test/common/route.spec.js', ['client', 'server']);
+    api.addFiles('test/common/group.spec.js', ['client', 'server']);
+  });
+  
+  Npm.depends({
+    page: '1.9.0',
+    qs: '6.10.5'
+  });
+  

--- a/package.js
+++ b/package.js
@@ -1,47 +1,76 @@
 Package.describe({
-  name: 'ostrio:flow-router-extra',
-  summary: 'Carefully extended flow-router with waitOn and template context',
-  version: '3.8.1',
-  git: 'https://github.com/veliovgroup/flow-router'
+    name: "ostrio:flow-router-extra",
+    summary: "Carefully extended flow-router with waitOn and template context",
+    version: "3.8.1",
+    git: "https://github.com/veliovgroup/flow-router",
 });
 
 Package.onUse((api) => {
-  api.versionsFrom('1.4');
-  api.use(['modules', 'ecmascript', 'promise', 'tracker', 'reactive-dict', 'reactive-var', 'ejson', 'check'], ['client', 'server']);
+    api.versionsFrom("1.4");
+    api.use(
+        [
+            "modules",
+            "ecmascript",
+            "promise",
+            "tracker",
+            "reactive-dict",
+            "reactive-var",
+            "ejson",
+            "check",
+            "zodern:types@1.0.1",
+        ],
+        ["client", "server"]
+    );
 
-  api.use(['templating', 'blaze'], 'client', { weak: true });
-  api.mainModule('client/_init.js', 'client');
-  api.mainModule('server/_init.js', 'server');
+    api.use(["templating", "blaze"], "client", { weak: true });
+    api.mainModule("client/_init.js", "client");
+    api.mainModule("server/_init.js", "server");
 });
 
 Package.onTest((api) => {
-  api.use(['ecmascript', 'tinytest', 'underscore', 'check', 'mongo', 'http', 'random', 'communitypackages:fast-render@4.0.6', 'communitypackages:inject-data@2.3.1', 'montiapm:meteorx@2.2.0', 'ostrio:flow-router-extra'], ['client', 'server']);
-  api.use(['reactive-var', 'tracker'], 'client');
+    api.use(
+        [
+            "ecmascript",
+            "tinytest",
+            "underscore",
+            "check",
+            "mongo",
+            "http",
+            "random",
+            "communitypackages:fast-render@4.0.6",
+            "communitypackages:inject-data@2.3.1",
+            "montiapm:meteorx@2.2.0",
+            "ostrio:flow-router-extra",
+            "zodern:types@1.0.1",
+        ],
+        ["client", "server"]
+    );
+    api.use(["reactive-var", "tracker"], "client");
 
-  api.addFiles('test/common/fast_render_route.js', ['client', 'server']);
+    api.addFiles("test/common/fast_render_route.js", ["client", "server"]);
 
-  api.addFiles('test/client/_helpers.js', 'client');
-  api.addFiles('test/server/_helpers.js', 'server');
+    api.addFiles("test/client/_helpers.js", "client");
+    api.addFiles("test/server/_helpers.js", "server");
 
-  api.addFiles('test/client/loader.spec.js', 'client');
-  api.addFiles('test/client/route.reactivity.spec.js', 'client');
-  api.addFiles('test/client/router.core.spec.js', 'client');
-  api.addFiles('test/client/router.subs_ready.spec.js', 'client');
-  api.addFiles('test/client/router.reactivity.spec.js', 'client');
-  api.addFiles('test/client/group.spec.js', 'client');
-  api.addFiles('test/client/trigger.spec.js', 'client');
-  api.addFiles('test/client/triggers.js', 'client');
+    api.addFiles("test/client/loader.spec.js", "client");
+    api.addFiles("test/client/route.reactivity.spec.js", "client");
+    api.addFiles("test/client/router.core.spec.js", "client");
+    api.addFiles("test/client/router.subs_ready.spec.js", "client");
+    api.addFiles("test/client/router.reactivity.spec.js", "client");
+    api.addFiles("test/client/group.spec.js", "client");
+    api.addFiles("test/client/trigger.spec.js", "client");
+    api.addFiles("test/client/triggers.js", "client");
 
-  api.addFiles('test/server/plugins/fast_render.js', 'server');
+    api.addFiles("test/server/plugins/fast_render.js", "server");
 
-  api.addFiles('test/common/router.path.spec.js', ['client', 'server']);
-  api.addFiles('test/common/router.url.spec.js', ['client', 'server']);
-  api.addFiles('test/common/router.addons.spec.js', ['client', 'server']);
-  api.addFiles('test/common/route.spec.js', ['client', 'server']);
-  api.addFiles('test/common/group.spec.js', ['client', 'server']);
+    api.addFiles("test/common/router.path.spec.js", ["client", "server"]);
+    api.addFiles("test/common/router.url.spec.js", ["client", "server"]);
+    api.addFiles("test/common/router.addons.spec.js", ["client", "server"]);
+    api.addFiles("test/common/route.spec.js", ["client", "server"]);
+    api.addFiles("test/common/group.spec.js", ["client", "server"]);
 });
 
 Npm.depends({
-  page: '1.9.0',
-  qs: '6.10.5'
+    page: "1.9.0",
+    qs: "6.10.5",
 });

--- a/package.js
+++ b/package.js
@@ -1,48 +1,47 @@
 Package.describe({
-    name: 'ostrio:flow-router-extra',
-    summary: 'Carefully extended flow-router with waitOn and template context',
-    version: '3.8.1',
-    git: 'https://github.com/veliovgroup/flow-router'
-  });
-  
-  Package.onUse((api) => {
-    api.versionsFrom('1.4');
-    api.use(['modules', 'ecmascript', 'promise', 'tracker', 'reactive-dict', 'reactive-var', 'ejson', 'check', 'zodern:types'], ['client', 'server']);
-  
-    api.use(['templating', 'blaze'], 'client', { weak: true });
-    api.mainModule('client/_init.js', 'client');
-    api.mainModule('server/_init.js', 'server');
-  });
-  
-  Package.onTest((api) => {
-    api.use(['ecmascript', 'tinytest', 'underscore', 'check', 'mongo', 'http', 'random', 'communitypackages:fast-render@4.0.6', 'communitypackages:inject-data@2.3.1', 'montiapm:meteorx@2.2.0', 'ostrio:flow-router-extra', 'zodern:types'], ['client', 'server']);
-    api.use(['reactive-var', 'tracker'], 'client');
-  
-    api.addFiles('test/common/fast_render_route.js', ['client', 'server']);
-  
-    api.addFiles('test/client/_helpers.js', 'client');
-    api.addFiles('test/server/_helpers.js', 'server');
-  
-    api.addFiles('test/client/loader.spec.js', 'client');
-    api.addFiles('test/client/route.reactivity.spec.js', 'client');
-    api.addFiles('test/client/router.core.spec.js', 'client');
-    api.addFiles('test/client/router.subs_ready.spec.js', 'client');
-    api.addFiles('test/client/router.reactivity.spec.js', 'client');
-    api.addFiles('test/client/group.spec.js', 'client');
-    api.addFiles('test/client/trigger.spec.js', 'client');
-    api.addFiles('test/client/triggers.js', 'client');
-  
-    api.addFiles('test/server/plugins/fast_render.js', 'server');
-  
-    api.addFiles('test/common/router.path.spec.js', ['client', 'server']);
-    api.addFiles('test/common/router.url.spec.js', ['client', 'server']);
-    api.addFiles('test/common/router.addons.spec.js', ['client', 'server']);
-    api.addFiles('test/common/route.spec.js', ['client', 'server']);
-    api.addFiles('test/common/group.spec.js', ['client', 'server']);
-  });
-  
-  Npm.depends({
-    page: '1.9.0',
-    qs: '6.10.5'
-  });
-  
+  name: 'ostrio:flow-router-extra',
+  summary: 'Carefully extended flow-router with waitOn and template context',
+  version: '3.8.1',
+  git: 'https://github.com/veliovgroup/flow-router'
+});
+
+Package.onUse((api) => {
+  api.versionsFrom('1.4');
+  api.use(['modules', 'ecmascript', 'promise', 'tracker', 'reactive-dict', 'reactive-var', 'ejson', 'check', 'zodern:types'], ['client', 'server']);
+
+  api.use(['templating', 'blaze'], 'client', { weak: true });
+  api.mainModule('client/_init.js', 'client');
+  api.mainModule('server/_init.js', 'server');
+});
+
+Package.onTest((api) => {
+  api.use(['ecmascript', 'tinytest', 'underscore', 'check', 'mongo', 'http', 'random', 'communitypackages:fast-render@4.0.6', 'communitypackages:inject-data@2.3.1', 'montiapm:meteorx@2.2.0', 'ostrio:flow-router-extra', 'zodern:types'], ['client', 'server']);
+  api.use(['reactive-var', 'tracker'], 'client');
+
+  api.addFiles('test/common/fast_render_route.js', ['client', 'server']);
+
+  api.addFiles('test/client/_helpers.js', 'client');
+  api.addFiles('test/server/_helpers.js', 'server');
+
+  api.addFiles('test/client/loader.spec.js', 'client');
+  api.addFiles('test/client/route.reactivity.spec.js', 'client');
+  api.addFiles('test/client/router.core.spec.js', 'client');
+  api.addFiles('test/client/router.subs_ready.spec.js', 'client');
+  api.addFiles('test/client/router.reactivity.spec.js', 'client');
+  api.addFiles('test/client/group.spec.js', 'client');
+  api.addFiles('test/client/trigger.spec.js', 'client');
+  api.addFiles('test/client/triggers.js', 'client');
+
+  api.addFiles('test/server/plugins/fast_render.js', 'server');
+
+  api.addFiles('test/common/router.path.spec.js', ['client', 'server']);
+  api.addFiles('test/common/router.url.spec.js', ['client', 'server']);
+  api.addFiles('test/common/router.addons.spec.js', ['client', 'server']);
+  api.addFiles('test/common/route.spec.js', ['client', 'server']);
+  api.addFiles('test/common/group.spec.js', ['client', 'server']);
+});
+
+Npm.depends({
+  page: '1.9.0',
+  qs: '6.10.5'
+});

--- a/package.js
+++ b/package.js
@@ -17,7 +17,7 @@ Package.onUse((api) => {
             "reactive-var",
             "ejson",
             "check",
-            "zodern:types@1.0.1",
+            "zodern:types",
         ],
         ["client", "server"]
     );
@@ -41,7 +41,7 @@ Package.onTest((api) => {
             "communitypackages:inject-data@2.3.1",
             "montiapm:meteorx@2.2.0",
             "ostrio:flow-router-extra",
-            "zodern:types@1.0.1",
+            "zodern:types",
         ],
         ["client", "server"]
     );

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,50 +1,129 @@
-type Trigger = (
-    context: {},
-    doRedirect: (url: string, params?: { key: string }, queryParams?: { [key: string]: string }) => void,
-    doStop: () => void
-) => void;
+type Trigger = (context: ReturnType<Router["current"]>, redirect: Router["go"], stop: () => void, data: any) => void;
 
-type TriggerFilter = {
-    only?: string[];
-    except?: string[];
+type TriggerFilterParam = { only: string[] } | { except: string[] };
+
+type DynamicImport<T extends string> = Promise<typeof import(T)>;
+
+type Hook = (params: Param, qs: QueryParam) => void;
+
+type waitOn = (
+    params: Param,
+    qs: QueryParam,
+    ready: () => void
+) =>
+    | Promise<any>
+    | Array<Promise<any>>
+    | Meteor.SubscriptionHandle
+    | Array<Meteor.SubscriptionHandle>
+    | Tracker<any>
+    | Array<Tracker<any>>
+    | DynamicImport<string>
+    | Array<DynamicImport<string>>;
+
+type waitOnResources = (
+    params: Param,
+    qs: QueryParam
+) => {
+    images: string[];
+    other: string[];
 };
-type TriggerFilterParam = TriggerFilter | TriggerFilter[];
+
+type data = (params: Param, qs: QueryParam) => Mongo.CursorStatic | Object | Object[] | false | null | void;
+
+type action = (params: Param, qs: QueryParam, data: any) => void;
+
+type Param = {
+    [key: string]: string;
+};
+
+type QueryParam = Param;
 
 interface Router {
-    getQueryParam: (param: string) => string | undefined;
-    getParam: (param: string) => string | undefined;
-    subscriptions?: any;
-    register: (name: string, sub: any) => void;
+    go: (path: string, params?: { [key: string]: string }, qs?: { [key: string]: string }) => boolean;
     route: (
         path: string,
         options?: {
             name?: string;
-            action?: () => void;
-            subscriptions?: (params: { [key: string]: string }) => void;
-            triggersEnter?: Trigger[];
-            triggersExit?: Trigger[];
-        },
-        group?: any
-    ) => any;
-    group: (options: any) => any;
-    path: (pathDef: string, fields?: { [key: string]: string }, queryParams?: { [key: string]: string }) => string;
-    go: (pathDef: string, fields?: { [key: string]: string }, queryParams?: { [key: string]: string }) => void;
+            whileWaiting?: Hook;
+            waitOn?: waitOn;
+            waitOnResources?: waitOnResources;
+            endWaiting?: () => void;
+            data?: data;
+            onNoData?: Hook;
+            triggersEnter?: Array<Trigger>;
+            action?: action;
+            triggersExit?: Array<Trigger>;
+            conf: { [key: string]: any; forceReRender: boolean };
+            [key: string]: any;
+        }
+    ) => Route;
+    group: (options: { name: string; prefix: string; [key: string]: any }) => any;
+    render: (layout: string, template: string, data?: { [key: string]: any }, callback?: () => void) => void;
+
+    refresh: (layout: string, template: string) => void;
     reload: () => void;
-    redirect: (path: string) => void;
-    setQueryParams: (newParams: { [key: string]: string | null | undefined | number }) => boolean;
+    pathRegExp: RegExp;
+    decodeQueryParamsOnce: boolean;
+
+    getParam: (param: string) => string;
+    getQueryParam: (param: string) => string;
+    setParams: (params: Param) => boolean;
+    setQueryParams: (params: QueryParam) => boolean;
+
+    url: (path: string, params?: Param, qs?: QueryParam) => string;
+    path: (path: string, params?: Param, qs?: QueryParam) => string;
     current: () => {
+        context: Context;
+        oldRoute: Route;
+        params: Param;
         path: string;
-        context: any;
-        params: string[];
-        queryParams: { [key: string]: string };
+        queryParams: QueryParam;
+        route: Route;
     };
     getRouteName: () => string;
+
     watchPathChange: () => void;
-    subsRead: () => boolean;
+    withReplaceState: (callback: () => void) => void;
+
+    onRouteRegister: (callback: (route: Route) => void) => void;
+
+    wait: () => void;
+    initialize: (options: { hashbang: boolean; page: { click: boolean } }) => void;
+
     triggers: {
         enter: (triggers: Trigger[], filter?: TriggerFilterParam) => void;
         exit: (triggers: Trigger[], filter?: TriggerFilterParam) => void;
     };
 }
 
+interface Route {
+    conf: { [key: string]: string | boolean };
+    globals: Array<any>;
+    group: string;
+    name: string;
+    options: { name: string };
+    path: string;
+    pathDef: string;
+    render: () => void;
+}
+
+type Context = {
+    canonicalPath: string;
+    hash: string;
+    params: Param;
+    path: string;
+    pathname: string;
+    querystring: string;
+    state: { [key: string]: string };
+    title: string;
+};
+
+interface Helpers {
+    name: (routeName: string | RegExp) => boolean;
+    path: (pathName: string | RegExp) => boolean;
+    pathFor: (pathName: string, params: Param) => string;
+    configure: (options: { activeClass: string; caseSensitive: boolean; disabledClass: string; regex: string }) => void;
+}
+
 export const FlowRouter: Router;
+export const RouterHelpers: Helpers;

--- a/types.d.ts
+++ b/types.d.ts
@@ -9,16 +9,15 @@ type Hook = (params: Param, qs: QueryParam) => void;
 type waitOn = (
     params: Param,
     qs: QueryParam,
-    ready: () => void
+    ready: (func: () => ReturnType<waitOn>) => void
 ) =>
     | Promise<any>
     | Array<Promise<any>>
     | Meteor.SubscriptionHandle
-    | Array<Meteor.SubscriptionHandle>
-    | typeof Tracker.autorun
-    | Array<typeof Tracker.autorun>
+    | Tracker.Computation
+    | Array<Tracker.Computation>
     | DynamicImport<string>
-    | Array<DynamicImport<string>>;
+    | Array<DynamicImport<string> | Meteor.SubscriptionHandle>;
 
 type waitOnResources = (
     params: Param,
@@ -53,7 +52,7 @@ interface Router {
             triggersEnter?: Array<Trigger>;
             action?: action;
             triggersExit?: Array<Trigger>;
-            conf: { [key: string]: any; forceReRender: boolean };
+            conf?: { [key: string]: any; forceReRender?: boolean };
             [key: string]: any;
         }
     ) => Route;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,50 @@
+type Trigger = (
+    context: {},
+    doRedirect: (url: string, params?: { key: string }, queryParams?: { [key: string]: string }) => void,
+    doStop: () => void
+) => void;
+
+type TriggerFilter = {
+    only?: string[];
+    except?: string[];
+};
+type TriggerFilterParam = TriggerFilter | TriggerFilter[];
+
+interface Router {
+    getQueryParam: (param: string) => string | undefined;
+    getParam: (param: string) => string | undefined;
+    subscriptions?: any;
+    register: (name: string, sub: any) => void;
+    route: (
+        path: string,
+        options?: {
+            name?: string;
+            action?: () => void;
+            subscriptions?: (params: { [key: string]: string }) => void;
+            triggersEnter?: Trigger[];
+            triggersExit?: Trigger[];
+        },
+        group?: any
+    ) => any;
+    group: (options: any) => any;
+    path: (pathDef: string, fields?: { [key: string]: string }, queryParams?: { [key: string]: string }) => string;
+    go: (pathDef: string, fields?: { [key: string]: string }, queryParams?: { [key: string]: string }) => void;
+    reload: () => void;
+    redirect: (path: string) => void;
+    setQueryParams: (newParams: { [key: string]: string | null | undefined | number }) => boolean;
+    current: () => {
+        path: string;
+        context: any;
+        params: string[];
+        queryParams: { [key: string]: string };
+    };
+    getRouteName: () => string;
+    watchPathChange: () => void;
+    subsRead: () => boolean;
+    triggers: {
+        enter: (triggers: Trigger[], filter?: TriggerFilterParam) => void;
+        exit: (triggers: Trigger[], filter?: TriggerFilterParam) => void;
+    };
+}
+
+export const FlowRouter: Router;

--- a/types.d.ts
+++ b/types.d.ts
@@ -15,8 +15,8 @@ type waitOn = (
     | Array<Promise<any>>
     | Meteor.SubscriptionHandle
     | Array<Meteor.SubscriptionHandle>
-    | Tracker<any>
-    | Array<Tracker<any>>
+    | typeof Tracker.autorun
+    | Array<typeof Tracker.autorun>
     | DynamicImport<string>
     | Array<DynamicImport<string>>;
 


### PR DESCRIPTION
As discussed in [issue](https://github.com/veliovgroup/flow-router/issues/84) there was an old request to add typescript types to this package. 

This is a first start for implementing typescript types for Flow-Router extra. Basic setup from monti-apm routes types, but updated according to the docs from Flow-Router-Extra. 

I still have a few small questions and a bug in the code itself that I wasn't able to figure out and could use the help from someone else with. 

On the [FlowRouter.current()](https://github.com/veliovgroup/flow-router/blob/master/docs/api/current.md) documentation page, it is mentioned that the return value is an Object with 4 params, but there are more (as seen in the types file). 

Later in the docs on the [triggersEnter](https://github.com/veliovgroup/flow-router/blob/master/docs/hooks/triggersEnter.md) page, it is mentioned that the function has a property called: context {Route} that is equal to FlowRouter.current() function. 
But the FlowRouter.current() function has a context prop that it returns with different props. I think my implementation for the types is correct, but this might be a separate issue with the documentation that could be improved.

My issue is with the dynamic import (return type for waitOn function).
type DynamicImport<T extends string> = Promise<typeof import(T)>;
I have tried the following solution, but it's giving the error message at the last T: String literal expected.
 
