### PR TITLE
docs(TypeScript): Add reference about how to make TS types work

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ FlowRouter.route('*', {
 });
 ```
 
+> NOTE: If you're using TypeScript, FlowRouter supports it. For types to work you need to install and follow the instructions of [zodern:meteor-types](https://github.com/zodern/meteor-types#meteor-apps) if you haven't done it already.
+
 ## Documentation
 
 - Continue with our [wiki](https://github.com/veliovgroup/flow-router/wiki);


### PR DESCRIPTION
This PR adds a small description about how to make use of the TS types.

I'm back at using meteor after a long time of no using it, not even doing frontend so the first package I installed was this one and had a hard time finding how to make the types work. I suspect many will do something similar.

Added a small description that should point people in the right direction for using TS with meteor packages, being this package one of the most popular ones.

Thanks!