### PR TITLE
Update Router.go signature to accept null for params

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,8 +74,8 @@ interface Router {
     setParams: (params: Param) => boolean;
     setQueryParams: (params: QueryParam) => boolean;
 
-    url: (path: string, params?: Param, qs?: QueryParam) => string;
-    path: (path: string, params?: Param, qs?: QueryParam) => string;
+    url: (path: string, params?: Param | null, qs?: QueryParam) => string;
+    path: (path: string, params?: Param | null, qs?: QueryParam) => string;
     current: () => {
         context: Context;
         oldRoute: Route;

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ type Param = {
 type QueryParam = Param;
 
 interface Router {
-    go: (path: string, params?: { [key: string]: string }, qs?: { [key: string]: string }) => boolean;
+    go: (path: string, params?: Param | null, qs?: QueryParam) => boolean;
     route: (
         path: string,
         options?: {


### PR DESCRIPTION
Resolves #104 

This PR updates the signatures to `Router.go`, `Router.path`, and `Router.url` to allow passing `null` as the `params` argument. This makes code more clear when you want to call `Router.go` without any parameters, yet need to pass the `qs` argument.

```javascript
Router.go('someRoute', null, { q: 'a+query' });
```

Previously you would need to pass `undefined` as the second argument.

```javascript
Router.go('someRoute', undefined, { q: 'a+query' });
```