### PR TITLE
Add TypeScript definition file for package assets

### DIFF
--- a/package.js
+++ b/package.js
@@ -13,6 +13,9 @@ Package.onUse((api) => {
   api.use(['templating', 'blaze'], 'client', { weak: true });
   api.mainModule('client/_init.js', 'client');
   api.mainModule('server/_init.js', 'server');
+
+  // For zodern:types to pick up our published types.
+  api.addAssets('index.d.ts', ['client', 'server']);
 });
 
 Package.onTest((api) => {


### PR DESCRIPTION
Resolves #116 

This PR adds the `index.d.ts` file back into the package assets so the `zodern:types` can copy them over to the project directory.

### Before:
![image](https://github.com/user-attachments/assets/5099d1e5-0807-4dfb-8ed4-46be09a1b3e8)
```
File '[project-directory]/.meteor/local/types/packages.d.ts' is not a module.ts(2306)
```

### After:
![image](https://github.com/user-attachments/assets/b686b85c-ca63-4360-a44e-0d2656cbf2f3)
![image](https://github.com/user-attachments/assets/7db2d305-c676-4def-ab97-0f55340a09ce)
