### PR TITLE
Fix data context handling in `_load` to align with Blaze@3.0.1

### DIFF
--- a/client/renderer.js
+++ b/client/renderer.js
@@ -246,11 +246,11 @@ class BlazeRenderer {
 
   _load(updateTemplate, updateLayout, current) {
     if (updateLayout && current.layout.view) {
-      current.layout.view.dataVar.set(current.data);
+      current.layout.view.dataVar.set({ value: current.data ?? {} });
     }
 
     if (current.template.view && updateTemplate) {
-      current.template.view.dataVar.set(current.data);
+      current.template.view.dataVar.set({ value: current.data ?? {} });
       this.isRendering = false;
       current.materialized = true;
       current.callback();

--- a/client/renderer.js
+++ b/client/renderer.js
@@ -250,7 +250,7 @@ class BlazeRenderer {
     }
 
     if (current.template.view && updateTemplate) {
-      current.layout.view.dataVar.set(current.layout.view.dataVar.get()?.value ? { value: current.data ?? {} } : current.data);
+      current.template.view.dataVar.set(current.template.view.dataVar.get()?.value ? { value: current.data ?? {} } : current.data);
       this.isRendering = false;
       current.materialized = true;
       current.callback();

--- a/client/renderer.js
+++ b/client/renderer.js
@@ -246,11 +246,11 @@ class BlazeRenderer {
 
   _load(updateTemplate, updateLayout, current) {
     if (updateLayout && current.layout.view) {
-      current.layout.view.dataVar.set({ value: current.data ?? {} });
+      current.layout.view.dataVar.set(current.layout.view.dataVar.get()?.value ? { value: current.data ?? {} } : current.data);
     }
 
     if (current.template.view && updateTemplate) {
-      current.template.view.dataVar.set({ value: current.data ?? {} });
+      current.layout.view.dataVar.set(current.layout.view.dataVar.get()?.value ? { value: current.data ?? {} } : current.data);
       this.isRendering = false;
       current.materialized = true;
       current.callback();


### PR DESCRIPTION
In Blaze@3.0.1, `dataVar.set()` now requires an object `{ value: current.data ?? {} }` instead of setting `current.data` directly.

This commit updates `ostrio:flow-router-extra@3.11.0` to follow this change and ensure proper data propagation in templates and layouts.

https://github.com/veliovgroup/flow-router/issues/120