### PR TITLE
Expose pending route name reactively

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -19,6 +19,8 @@ class Router {
     this._tracker = this._buildTracker();
     this._current = {};
     this._onEveryPath = new Tracker.Dependency();
+    this._activeRouteName = undefined;
+    this._activeRouteDep = new Tracker.Dependency();
 
     this.maxWaitFor = MAX_WAIT_FOR_MS;
     this._globalRoute = new Route(this);
@@ -105,6 +107,12 @@ class Router {
         oldRoute,
         queryParams
       };
+
+      const activeRouteName = route.name;
+      if (this._activeRouteName !== activeRouteName) {
+        this._activeRouteName = activeRouteName;
+        this._activeRouteDep.changed();
+      }
 
       const afterAllTriggersRan = () => {
         this._invalidateTracker();
@@ -286,6 +294,17 @@ class Router {
     current.queryParams = EJSON.clone(current.queryParams);
     current.params = EJSON.clone(current.params);
     return current;
+  }
+
+  /**
+   * Reactively returns the route currently being navigated to.
+   *
+   * Unlike getRouteName(), this dependency changes before waitOn completes,
+   * making it suitable for optimistic navigation UI such as active links.
+   */
+  getActiveRouteNameReactive() {
+    this._activeRouteDep.depend();
+    return this._activeRouteName;
   }
 
   track(reactiveMapper) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -96,6 +96,8 @@ export interface Router {
         route: Route;
     };
     getRouteName: () => string;
+    /** Reactive route target, updated before `waitOn` completes. */
+    getActiveRouteNameReactive: () => string | undefined;
 
     watchPathChange: () => void;
     withReplaceState: (callback: () => void) => void;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -49,6 +49,7 @@ FlowRouter.go('/');
 expectType<string>(FlowRouter.current().route.name);
 expectType<string>(FlowRouter.current().path);
 expectType<Record<string, string>>(FlowRouter.current().params);
+expectType<string | undefined>(FlowRouter.getActiveRouteNameReactive());
 
 FlowRouter.route('/post/:id', {
   name: 'singlePost',

--- a/test/client/router.core.spec.js
+++ b/test/client/router.core.spec.js
@@ -222,6 +222,35 @@ Tinytest.addAsync('Client - Router - define and go to route with async waitOn', 
   }, 10);
 });
 
+Tinytest.addAsync('Client - Router - active route name reacts before waitOn completes', (test, next) => {
+  const rand = Random.id();
+  const routeName = `active-${rand}`;
+  const observed = [];
+  let releaseWaitOn;
+
+  FlowRouter.route('/' + rand, {
+    name: routeName,
+    waitOn() {
+      return new Promise((resolve) => {
+        releaseWaitOn = resolve;
+      });
+    }
+  });
+
+  const computation = Tracker.autorun(() => {
+    observed.push(FlowRouter.getActiveRouteNameReactive());
+  });
+
+  FlowRouter.go('/' + rand);
+
+  Meteor.setTimeout(() => {
+    test.equal(observed.at(-1), routeName);
+    releaseWaitOn();
+    computation.stop();
+    next();
+  }, 20);
+});
+
 Tinytest.addAsync('Client - Router - waitOn aborts when navigating away', (test, next) => {
   const randA = Random.id();
   const randB = Random.id();


### PR DESCRIPTION
## Summary

- add `getActiveRouteNameReactive()` for UI that should reflect a navigation target before `waitOn` completes
- keep existing `current()` / `getRouteName()` loaded-route reactivity unchanged
- add runtime and TypeScript coverage

This came from a real navigation UX issue: active-link UI otherwise remains on the previous route throughout a slow `waitOn`, even though the router has already committed to the destination.

FWIW: I've had this code in my app in production for months now.

## Tests

- `meteor npm run test:once` (193 passed)
- `meteor npm run test:types`